### PR TITLE
Change source for flake8 import

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,8 @@ repos:
   hooks:
   - id: isort
 
-- repo: https://gitlab.com/PyCQA/flake8
-  rev: 4.0.1
+- repo: https://github.com/PyCQA/flake8
+  rev: 5.0.4
   hooks:
   - id: flake8
 


### PR DESCRIPTION
As title says. This is the recommended source for flake8 for PyAnsys libraries.