### PR TITLE
Change to warning if no Ansys install is found

### DIFF
--- a/ansys/heart/preprocessor/__init__.py
+++ b/ansys/heart/preprocessor/__init__.py
@@ -36,5 +36,6 @@ elif os.name == "nt" and installed_versions:
 else:
     warnings.warn(
         "No valid Ansys installations found. Valid Ansys installations include: Ansys %s"
-        % supported_versions, Warning
+        % supported_versions,
+        Warning,
     )


### PR DESCRIPTION
Addresses issue #172. This should now not terminate the program anymore when no valid Ansys installation is found on Windows. 