### PR TITLE
Fix: remove EmDatabaseNodout

### DIFF
--- a/ansys/heart/writer/dynawriter.py
+++ b/ansys/heart/writer/dynawriter.py
@@ -3023,9 +3023,6 @@ class ElectrophysiologyDynaWriter(BaseDynaWriter):
         )
         self.kw_database.node_sets.append(kw)
 
-        self.kw_database.ep_settings.append(
-            keywords.EmDatabaseNodout(outlv=1, dtout=1, nsid=nsid_all_parts)
-        )
         # use defaults
         self.kw_database.ep_settings.append(custom_keywords.EmControlEp(numsplit=1))
 


### PR DESCRIPTION
Should massively speed up EP simulation since not all results are written to ascii anymore.