### PR TITLE
FIX: fibergeneration writer_update_nodesets_db

### DIFF
--- a/src/ansys/heart/writer/dynawriter.py
+++ b/src/ansys/heart/writer/dynawriter.py
@@ -318,7 +318,7 @@ class BaseDynaWriter:
 
         Notes
         -----
-        The removed node must be connected with more than 1 element, see #656.
+        The removed node must be connected with at least 1 node outside the boundary, see #656.
 
         Parameters
         ----------
@@ -392,7 +392,8 @@ class BaseDynaWriter:
 
         for cell in issue_tets:
             LOGGER.warning(
-                f"All nodes of cell {cell+1} are in nodeset of {surface.name}," " N1 is removed."
+                f"All nodes of cell {cell+1} are in nodeset of {surface.name},"
+                + " removing at least one node."
             )
 
         return node_ids

--- a/tests/heart/preprocessor/test_writer001.py
+++ b/tests/heart/preprocessor/test_writer001.py
@@ -87,3 +87,17 @@ def test_filter_bc_nodes02():
     # one node is removed, but not the node 0 since it's only attached with the issue element
     # see #656
     assert np.allclose(ids, [0, 2, 3])
+
+
+def test_filter_bc_nodes03():
+    model = get_test_model()
+    # filter is necessary but no individual nodes can be removed
+    model.left_ventricle.endocardium.triangles = np.array(
+        [[0, 1, 2], [0, 1, 3], [0, 2, 3], [1, 2, 4]], dtype=int
+    )
+    w = writers.FiberGenerationDynaWriter(model)
+    ids = w._filter_bc_nodes(model.left_ventricle.endocardium)
+
+    # all nodes in the unsolvable tetrahedron and their respective neighbors are removed
+    # see #656
+    assert len(ids) == 0


### PR DESCRIPTION
This PR modifies the behavior of BaseDynaWriter._update_nodesets_db() in the context of fiber generation.

It adds robustness to the removal of problematic boundary condition nodes on uneven surfaces.

The filtering process occurs in the new method _filter_bc_nodes, called when the flag remove_one_node_from_cell = True in _update_nodesets_db().