### PR TITLE
MAINT: bump ansys-dpf-core from 0.10.0 to 0.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "ansys-dpf-core==0.10.0",
+    "ansys-dpf-core==0.13.0",
     "ansys-fluent-core==0.24.2",
     "deprecated==1.2.14",
     "dynalib==0.1.0",


### PR DESCRIPTION
Should resolve a bug where PyDPF (wrongly) modifies the `PATH` environment variable. 