### PR TITLE
CI/CD: prioritize regular tests over smoke-tests

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -42,7 +42,7 @@ jobs:
   smoke-tests:
     name: "Build and Smoke tests"
     runs-on: ${{ matrix.os }}
-    needs: [code-style]
+    needs: [tests]
     strategy:
       fail-fast: false
       matrix:
@@ -85,7 +85,7 @@ jobs:
   tests:
     name: Tests
     runs-on: ${{ matrix.os }}
-    needs: [smoke-tests]
+    needs: [code-style]
     strategy:
       matrix:
 #        os: [windows-latest, macos-latest, ubuntu-latest]


### PR DESCRIPTION
@Revathyvenugopal162 since the build-smoke tests can take approx twice as long I propose to run regular (relatively quick) tests before running the build-smoke tests to get quicker feedback. 