### PR TITLE
refactor: deprecate element_ids attribute in Part class

### DIFF
--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -131,7 +131,7 @@ jobs:
           AWP_ROOT241: C:\\Program Files\\ANSYS Inc\\v241
           DPF_STANDALONE_PATH: C:\\Program Files\\ANSYS Inc\\dpf-server-2024.2rc0
           PYFLUENT_UI_MODE: no_gui # default hidden_gui fails on self-hosted runner
-          NIGHTLY_DOC_BUILD: 0
+          NIGHTLY_DOC_BUILD: 1
         run: |
           tox -e doc-html,doc-links,doc-pdf
           # Check if the examples folder exists and list its contents

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -131,7 +131,7 @@ jobs:
           AWP_ROOT241: C:\\Program Files\\ANSYS Inc\\v241
           DPF_STANDALONE_PATH: C:\\Program Files\\ANSYS Inc\\dpf-server-2024.2rc0
           PYFLUENT_UI_MODE: no_gui # default hidden_gui fails on self-hosted runner
-          NIGHTLY_DOC_BUILD: 1
+          NIGHTLY_DOC_BUILD: 0
         run: |
           tox -e doc-html,doc-links,doc-pdf
           # Check if the examples folder exists and list its contents

--- a/src/ansys/health/heart/models.py
+++ b/src/ansys/health/heart/models.py
@@ -1133,28 +1133,26 @@ class HeartModel:
 
         return
 
+    @deprecated(reason="Element IDs are now retrieved from the mesh object.")
     def _assign_elements_to_parts(self) -> None:
         """Get the element IDs of each part and assign these to the ``Part`` objects."""
-        # get element IDs of each part.
-        used_element_ids = self._get_used_element_ids()
+        # validate that all parts have element IDs assigned.
         for part in self.parts:
-            if len(part._element_ids) > 0:
+            if part.get_element_ids(self.mesh).shape == (0,):
                 LOGGER.warning(
-                    "Part {0} seems to already have elements assigned. Skipping.".format(part.name)
+                    """Part {0} has no elements assigned.
+                    Please check the mesh and part definitions.""".format(part.name)
                 )
                 continue
-            # ! this is valid as long as no additional surfaces are added in self.mesh.
-            # ! otherwise (global) element ids may change
-            # TODO: now all part ids are stored through the cell data _volume-ids and global
-            # TODO: element ids can be retrieved by: part.get_element_ids(mesh)
-            element_ids = np.where(np.isin(self.mesh.cell_data["_volume-id"], part.pid))[0]
-            element_ids = element_ids[np.isin(element_ids, used_element_ids, invert=True)]
-            part._element_ids = element_ids
 
         summ = 0
         for part in self.parts:
-            LOGGER.info("Num elements in {0}: {1}".format(part.name, part._element_ids.shape[0]))
-            summ = summ + part._element_ids.shape[0]
+            LOGGER.info(
+                "Num elements in {0}: {1}".format(
+                    part.name, part.get_element_ids(self.mesh).shape[0]
+                )
+            )
+            summ = summ + part.get_element_ids(self.mesh).shape[0]
         LOGGER.info("Total num elements: {}".format(summ))
 
         LOGGER.info(

--- a/src/ansys/health/heart/models.py
+++ b/src/ansys/health/heart/models.py
@@ -1375,7 +1375,7 @@ class HeartModel:
     def _validate_parts(self):
         """Validate that none of the parts are empty."""
         is_valid = False
-        invalid_parts = [p for p in self.parts if p._element_ids.shape[0] == 0]
+        invalid_parts = [p for p in self.parts if p.get_element_ids(self.mesh).shape == (0,)]
         if len(invalid_parts) == 0:
             is_valid = True
         else:

--- a/src/ansys/health/heart/models.py
+++ b/src/ansys/health/heart/models.py
@@ -1387,9 +1387,9 @@ class HeartModel:
         """Clean epicardial surfaces such that these use only nodes of the part."""
         for part in self.parts:
             self.mesh._set_global_ids()
-            global_node_ids_part = self.mesh.extract_cells(part._element_ids).point_data[
-                "_global-point-ids"
-            ]
+            global_node_ids_part = self.mesh.extract_cells(
+                part.get_element_ids(self.mesh)
+            ).point_data["_global-point-ids"]
 
             # ! The only information we use from surface here is the ID, not the mesh information.
             # ! We need to go back to the central mesh to obtain an updated copy of

--- a/src/ansys/health/heart/models.py
+++ b/src/ansys/health/heart/models.py
@@ -403,19 +403,14 @@ class HeartModel:
             LOGGER.error(f"Failed to create {name}. Name already exists.")
             return None
 
-        for part in self.parts:
-            try:
-                part._element_ids = np.setdiff1d(part._element_ids, eids)
-            except ValueError:
-                LOGGER.error(f"Failed to create part {name}.")
-                return None
+        new_part_id = self.mesh._unused_volume_id
 
         self.add_part(name)
         new_part: anatomy.Part = self.get_part(name)
+        new_part.pid = new_part_id
 
-        new_part.pid = self.mesh._unused_volume_id
-
-        # Modify the cell data of the mesh to reflect the new part.
+        # Update the mesh accordingly. Note that this also affects other parts, since
+        # only one volume ID can be assigned to each element/cell.
         self.mesh.cell_data["_volume-id"][eids] = new_part.pid
         self.mesh._volume_id_to_name[new_part.pid] = name
 
@@ -1680,7 +1675,7 @@ class FourChamber(HeartModel):
             connected_cells = clean_obj["cell_ids"]
             orphan_cells = np.setdiff1d(atrium._element_ids, connected_cells)
 
-            # keeep largest connected part for atrial
+            # keep largest connected part for atrial
             atrium._element_ids = connected_cells
 
             # get orphan cells and set to isolation part
@@ -1744,7 +1739,13 @@ class FourChamber(HeartModel):
         # above search may create orphan elements, pick them to rings
         self.mesh["cell_ids"] = np.arange(0, self.mesh.n_cells, dtype=int)
         unselect_eles = np.setdiff1d(
-            np.hstack((self.left_atrium._element_ids, self.right_atrium._element_ids)), ring_eles
+            np.hstack(
+                (
+                    self.left_atrium.get_element_ids(self.mesh),
+                    self.right_atrium.get_element_ids(self.mesh),
+                )
+            ),
+            ring_eles,
         )
         largest = self.mesh.extract_cells(unselect_eles).connectivity(extraction_mode="largest")
         connected_cells = largest["cell_ids"]

--- a/src/ansys/health/heart/models.py
+++ b/src/ansys/health/heart/models.py
@@ -413,7 +413,15 @@ class HeartModel:
         self.add_part(name)
         new_part: anatomy.Part = self.get_part(name)
 
-        new_part._element_ids = eids
+        new_part.pid = self.mesh._unused_volume_id
+
+        # Modify the cell data of the mesh to reflect the new part.
+        self.mesh.cell_data["_volume-id"][eids] = new_part.pid
+        self.mesh._volume_id_to_name[new_part.pid] = name
+
+        # To maintain compatibility in other modules.
+        # TODO: remove this when element_ids is deprecated.
+        new_part._element_ids = new_part.get_element_ids(self.mesh)
 
         return new_part
 
@@ -1148,6 +1156,8 @@ class HeartModel:
                 continue
             # ! this is valid as long as no additional surfaces are added in self.mesh.
             # ! otherwise (global) element ids may change
+            # TODO: now all part ids are stored through the cell data _volume-ids and global
+            # TODO: element ids can be retrieved by: part.get_element_ids(mesh)
             element_ids = np.where(np.isin(self.mesh.cell_data["_volume-id"], part.pid))[0]
             element_ids = element_ids[np.isin(element_ids, used_element_ids, invert=True)]
             part._element_ids = element_ids

--- a/src/ansys/health/heart/models.py
+++ b/src/ansys/health/heart/models.py
@@ -405,7 +405,7 @@ class HeartModel:
 
         for part in self.parts:
             try:
-                part.element_ids = np.setdiff1d(part.element_ids, eids)
+                part._element_ids = np.setdiff1d(part._element_ids, eids)
             except ValueError:
                 LOGGER.error(f"Failed to create part {name}.")
                 return None
@@ -413,7 +413,7 @@ class HeartModel:
         self.add_part(name)
         new_part: anatomy.Part = self.get_part(name)
 
-        new_part.element_ids = eids
+        new_part._element_ids = eids
 
         return new_part
 
@@ -670,7 +670,7 @@ class HeartModel:
 
         plotter = pv.Plotter()
         plotter.add_mesh(mesh, opacity=0.5, color="white")
-        part = mesh.extract_cells(part.element_ids)
+        part = mesh.extract_cells(part._element_ids)
         plotter.add_mesh(part, opacity=0.95, color="red")
         plotter.show()
         return
@@ -866,7 +866,7 @@ class HeartModel:
             part_1.pid = part_info[part_1.name]["part-id"]
 
             try:
-                part_1.element_ids = np.argwhere(
+                part_1._element_ids = np.argwhere(
                     np.isin(self.mesh.cell_data["_volume-id"], part_1.pid)
                 ).flatten()
             except Exception as e:
@@ -922,7 +922,7 @@ class HeartModel:
         """Get an array of used element IDs."""
         element_ids = np.empty(0, dtype=int)
         for part in self.parts:
-            element_ids = np.append(element_ids, part.element_ids)
+            element_ids = np.append(element_ids, part._element_ids)
 
         return element_ids
 
@@ -1062,15 +1062,15 @@ class HeartModel:
 
         # assign to septum
         part = next(part for part in self.parts if isinstance(part, anatomy.Septum))
-        part.element_ids = element_ids_septum
+        part._element_ids = element_ids_septum
         # manipulate _volume-id
         self.mesh.cell_data["_volume-id"][element_ids_septum] = part.pid
         self.mesh._volume_id_to_name[int(part.pid)] = part.name
 
         # remove these element ID from the left-ventricle
         part = next(part for part in self.parts if part.name == "Left ventricle")
-        mask = np.isin(part.element_ids, element_ids_septum, invert=True)
-        part.element_ids = part.element_ids[mask]
+        mask = np.isin(part._element_ids, element_ids_septum, invert=True)
+        part._element_ids = part._element_ids[mask]
 
         return
 
@@ -1141,7 +1141,7 @@ class HeartModel:
         # get element IDs of each part.
         used_element_ids = self._get_used_element_ids()
         for part in self.parts:
-            if len(part.element_ids) > 0:
+            if len(part._element_ids) > 0:
                 LOGGER.warning(
                     "Part {0} seems to already have elements assigned. Skipping.".format(part.name)
                 )
@@ -1150,12 +1150,12 @@ class HeartModel:
             # ! otherwise (global) element ids may change
             element_ids = np.where(np.isin(self.mesh.cell_data["_volume-id"], part.pid))[0]
             element_ids = element_ids[np.isin(element_ids, used_element_ids, invert=True)]
-            part.element_ids = element_ids
+            part._element_ids = element_ids
 
         summ = 0
         for part in self.parts:
-            LOGGER.info("Num elements in {0}: {1}".format(part.name, part.element_ids.shape[0]))
-            summ = summ + part.element_ids.shape[0]
+            LOGGER.info("Num elements in {0}: {1}".format(part.name, part._element_ids.shape[0]))
+            summ = summ + part._element_ids.shape[0]
         LOGGER.info("Total num elements: {}".format(summ))
 
         LOGGER.info(
@@ -1376,7 +1376,7 @@ class HeartModel:
     def _validate_parts(self):
         """Validate that none of the parts are empty."""
         is_valid = False
-        invalid_parts = [p for p in self.parts if p.element_ids.shape[0] == 0]
+        invalid_parts = [p for p in self.parts if p._element_ids.shape[0] == 0]
         if len(invalid_parts) == 0:
             is_valid = True
         else:
@@ -1390,7 +1390,7 @@ class HeartModel:
         """Clean epicardial surfaces such that these use only nodes of the part."""
         for part in self.parts:
             self.mesh._set_global_ids()
-            global_node_ids_part = self.mesh.extract_cells(part.element_ids).point_data[
+            global_node_ids_part = self.mesh.extract_cells(part._element_ids).point_data[
                 "_global-point-ids"
             ]
 
@@ -1529,13 +1529,13 @@ class HeartModel:
             return
 
         eids = np.intersect1d(
-            np.where(v > threshold_left_ventricle)[0], self.left_ventricle.element_ids
+            np.where(v > threshold_left_ventricle)[0], self.left_ventricle._element_ids
         )
         if not isinstance(self, LeftVentricle):
             # uvc-L of RV is generally smaller, *1.05 to be comparable with LV
             eid_r = np.intersect1d(
                 np.where(v > threshold_right_ventricle)[0],
-                self.right_ventricle.element_ids,
+                self.right_ventricle._element_ids,
             )
             eids = np.hstack((eids, eid_r))
 
@@ -1638,9 +1638,9 @@ class FourChamber(HeartModel):
         #! at start of the mesh object.
         for part in self.parts:
             if isinstance(part, anatomy.Ventricle):
-                v_ele = np.append(v_ele, part.element_ids)
+                v_ele = np.append(v_ele, part._element_ids)
             elif isinstance(part, anatomy.Atrium):
-                a_ele = np.append(a_ele, part.element_ids)
+                a_ele = np.append(a_ele, part._element_ids)
 
         ventricles = self.mesh.extract_cells(v_ele)
         atrial = self.mesh.extract_cells(a_ele)
@@ -1656,26 +1656,28 @@ class FourChamber(HeartModel):
         interface_eids = np.intersect1d(interface_eids, a_ele)
 
         # remove these elements from atrial parts
-        self.left_atrium.element_ids = np.setdiff1d(self.left_atrium.element_ids, interface_eids)
-        self.right_atrium.element_ids = np.setdiff1d(self.right_atrium.element_ids, interface_eids)
+        self.left_atrium._element_ids = np.setdiff1d(self.left_atrium._element_ids, interface_eids)
+        self.right_atrium._element_ids = np.setdiff1d(
+            self.right_atrium._element_ids, interface_eids
+        )
 
         # find orphan elements of atrial parts and assign to isolation part
         self.mesh["cell_ids"] = np.arange(0, self.mesh.n_cells, dtype=int)
         for atrium in [self.left_atrium, self.right_atrium]:
-            clean_obj = self.mesh.extract_cells(atrium.element_ids).connectivity(
+            clean_obj = self.mesh.extract_cells(atrium._element_ids).connectivity(
                 extraction_mode="largest"
             )
             connected_cells = clean_obj["cell_ids"]
-            orphan_cells = np.setdiff1d(atrium.element_ids, connected_cells)
+            orphan_cells = np.setdiff1d(atrium._element_ids, connected_cells)
 
             # keeep largest connected part for atrial
-            atrium.element_ids = connected_cells
+            atrium._element_ids = connected_cells
 
             # get orphan cells and set to isolation part
             LOGGER.warning(f"{len(orphan_cells)} orphan cells are re-assigned.")
             interface_eids = np.append(interface_eids, orphan_cells)
 
-            #! Central mesh object not updated. E.g. lose connection between part.element_ids and
+            #! Central mesh object not updated. E.g. lose connection between part._element_ids and
             #! model.mesh.volume_ids/.cell_data["_volume-id"]
 
         if interface_eids.shape[0] == 0:
@@ -1732,7 +1734,7 @@ class FourChamber(HeartModel):
         # above search may create orphan elements, pick them to rings
         self.mesh["cell_ids"] = np.arange(0, self.mesh.n_cells, dtype=int)
         unselect_eles = np.setdiff1d(
-            np.hstack((self.left_atrium.element_ids, self.right_atrium.element_ids)), ring_eles
+            np.hstack((self.left_atrium._element_ids, self.right_atrium._element_ids)), ring_eles
         )
         largest = self.mesh.extract_cells(unselect_eles).connectivity(extraction_mode="largest")
         connected_cells = largest["cell_ids"]

--- a/src/ansys/health/heart/models.py
+++ b/src/ansys/health/heart/models.py
@@ -1636,9 +1636,9 @@ class FourChamber(HeartModel):
         #! at start of the mesh object.
         for part in self.parts:
             if isinstance(part, anatomy.Ventricle):
-                v_ele = np.append(v_ele, part._element_ids)
+                v_ele = np.append(v_ele, part.get_element_ids(self.mesh))
             elif isinstance(part, anatomy.Atrium):
-                a_ele = np.append(a_ele, part._element_ids)
+                a_ele = np.append(a_ele, part.get_element_ids(self.mesh))
 
         ventricles = self.mesh.extract_cells(v_ele)
         atrial = self.mesh.extract_cells(a_ele)
@@ -1653,30 +1653,22 @@ class FourChamber(HeartModel):
         # interface elements on atrial part
         interface_eids = np.intersect1d(interface_eids, a_ele)
 
-        # remove these elements from atrial parts
-        self.left_atrium._element_ids = np.setdiff1d(self.left_atrium._element_ids, interface_eids)
-        self.right_atrium._element_ids = np.setdiff1d(
-            self.right_atrium._element_ids, interface_eids
-        )
+        # Temporarily assign -1 to the interface elements to ensure these are not referenced
+        # by the atrial parts. These are reassigned to the isolation part later.
+        self.mesh.cell_data["_volume-id"][interface_eids] = -1
 
-        # find orphan elements of atrial parts and assign to isolation part
+        # Find orphan elements of atrial parts and add to list of isolation elements
         self.mesh["cell_ids"] = np.arange(0, self.mesh.n_cells, dtype=int)
         for atrium in [self.left_atrium, self.right_atrium]:
-            clean_obj = self.mesh.extract_cells(atrium._element_ids).connectivity(
+            clean_obj = self.mesh.extract_cells(atrium.get_element_ids(self.mesh)).connectivity(
                 extraction_mode="largest"
             )
             connected_cells = clean_obj["cell_ids"]
-            orphan_cells = np.setdiff1d(atrium._element_ids, connected_cells)
+            orphan_cells = np.setdiff1d(atrium.get_element_ids(self.mesh), connected_cells)
 
-            # keep largest connected part for atrial
-            atrium._element_ids = connected_cells
-
-            # get orphan cells and set to isolation part
+            # Get any orphan cells and add to isolation part
             LOGGER.warning(f"{len(orphan_cells)} orphan cells are re-assigned.")
             interface_eids = np.append(interface_eids, orphan_cells)
-
-            #! Central mesh object not updated. E.g. lose connection between part._element_ids and
-            #! model.mesh.volume_ids/.cell_data["_volume-id"]
 
         if interface_eids.shape[0] == 0:
             LOGGER.warning(
@@ -1685,14 +1677,19 @@ class FourChamber(HeartModel):
             )
             return None
 
-        # create a new part
         isolation: anatomy.Part = self.create_part_by_ids(
             interface_eids, "Atrioventricular isolation"
         )
         isolation._part_type = anatomy._PartType.ATRIUM
+        # Assign a new part ID to the isolation part
+        isolation.pid = self.mesh._unused_volume_id
         isolation.fiber = True
         isolation.active = False
         isolation.ep_material = EPMaterial.Insulator()
+
+        # Update the mesh with the isolation part ID, this "naturally" removes the elements
+        # from the atrial parts and overrides the temporary value of -1.
+        self.mesh.cell_data["_volume-id"][interface_eids] = isolation.pid
 
         return isolation
 

--- a/src/ansys/health/heart/models.py
+++ b/src/ansys/health/heart/models.py
@@ -673,7 +673,7 @@ class HeartModel:
 
         plotter = pv.Plotter()
         plotter.add_mesh(mesh, opacity=0.5, color="white")
-        part = mesh.extract_cells(part._element_ids)
+        part = mesh.extract_cells(part.get_element_ids(mesh))
         plotter.add_mesh(part, opacity=0.95, color="red")
         plotter.show()
         return

--- a/src/ansys/health/heart/models.py
+++ b/src/ansys/health/heart/models.py
@@ -925,7 +925,7 @@ class HeartModel:
         """Get an array of used element IDs."""
         element_ids = np.empty(0, dtype=int)
         for part in self.parts:
-            element_ids = np.append(element_ids, part._element_ids)
+            element_ids = np.append(element_ids, part.get_element_ids(self.mesh))
 
         return element_ids
 
@@ -1064,16 +1064,10 @@ class HeartModel:
         element_ids_septum = self.mesh._global_tetrahedron_ids[element_ids_septum]
 
         # assign to septum
-        part = next(part for part in self.parts if isinstance(part, anatomy.Septum))
-        part._element_ids = element_ids_septum
+        part_septum = next(part for part in self.parts if isinstance(part, anatomy.Septum))
         # manipulate _volume-id
-        self.mesh.cell_data["_volume-id"][element_ids_septum] = part.pid
-        self.mesh._volume_id_to_name[int(part.pid)] = part.name
-
-        # remove these element ID from the left-ventricle
-        part = next(part for part in self.parts if part.name == "Left ventricle")
-        mask = np.isin(part._element_ids, element_ids_septum, invert=True)
-        part._element_ids = part._element_ids[mask]
+        self.mesh.cell_data["_volume-id"][element_ids_septum] = part_septum.pid
+        self.mesh._volume_id_to_name[int(part_septum.pid)] = part_septum.name
 
         return
 
@@ -1540,7 +1534,7 @@ class HeartModel:
             # uvc-L of RV is generally smaller, *1.05 to be comparable with LV
             eid_r = np.intersect1d(
                 np.where(v > threshold_right_ventricle)[0],
-                self.right_ventricle._element_ids,
+                self.right_ventricle.get_element_ids(self.mesh),
             )
             eids = np.hstack((eids, eid_r))
 

--- a/src/ansys/health/heart/models.py
+++ b/src/ansys/health/heart/models.py
@@ -1654,7 +1654,8 @@ class FourChamber(HeartModel):
         interface_eids = np.intersect1d(interface_eids, a_ele)
 
         # Temporarily assign -1 to the interface elements to ensure these are not referenced
-        # by the atrial parts. These are reassigned to the isolation part later.
+        # by the atrial parts. These are reassigned to the isolation part in the call to
+        # create_part_by_ids.
         self.mesh.cell_data["_volume-id"][interface_eids] = -1
 
         # Find orphan elements of atrial parts and add to list of isolation elements
@@ -1682,14 +1683,9 @@ class FourChamber(HeartModel):
         )
         isolation._part_type = anatomy._PartType.ATRIUM
         # Assign a new part ID to the isolation part
-        isolation.pid = self.mesh._unused_volume_id
         isolation.fiber = True
         isolation.active = False
         isolation.ep_material = EPMaterial.Insulator()
-
-        # Update the mesh with the isolation part ID, this "naturally" removes the elements
-        # from the atrial parts and overrides the temporary value of -1.
-        self.mesh.cell_data["_volume-id"][interface_eids] = isolation.pid
 
         return isolation
 

--- a/src/ansys/health/heart/models.py
+++ b/src/ansys/health/heart/models.py
@@ -414,10 +414,6 @@ class HeartModel:
         self.mesh.cell_data["_volume-id"][eids] = new_part.pid
         self.mesh._volume_id_to_name[new_part.pid] = name
 
-        # To maintain compatibility in other modules.
-        # TODO: remove this when element_ids is deprecated.
-        new_part._element_ids = new_part.get_element_ids(self.mesh)
-
         return new_part
 
     def load_input(self, input_vtp: pv.PolyData, part_definitions: dict, scalar: str):

--- a/src/ansys/health/heart/models.py
+++ b/src/ansys/health/heart/models.py
@@ -1528,7 +1528,8 @@ class HeartModel:
             return
 
         eids = np.intersect1d(
-            np.where(v > threshold_left_ventricle)[0], self.left_ventricle._element_ids
+            np.where(v > threshold_left_ventricle)[0],
+            self.left_ventricle.get_element_ids(self.mesh),
         )
         if not isinstance(self, LeftVentricle):
             # uvc-L of RV is generally smaller, *1.05 to be comparable with LV

--- a/src/ansys/health/heart/models.py
+++ b/src/ansys/health/heart/models.py
@@ -864,12 +864,11 @@ class HeartModel:
 
             part_1.pid = part_info[part_1.name]["part-id"]
 
-            try:
-                part_1._element_ids = np.argwhere(
-                    np.isin(self.mesh.cell_data["_volume-id"], part_1.pid)
-                ).flatten()
-            except Exception as e:
-                LOGGER.warning(f"Failed to set element IDs for {part_1.name}. {e}")
+            if not np.isin(part_1.pid, self.mesh.volume_ids):
+                LOGGER.error(
+                    f"""Part {part_1.name} with ID {part_1.pid} is not in the mesh.
+                    Check {filename_mesh}."""
+                )
 
             # try to initialize cavity object.
             if isinstance(part_1, anatomy.Chamber):

--- a/src/ansys/health/heart/models_utils.py
+++ b/src/ansys/health/heart/models_utils.py
@@ -181,7 +181,9 @@ class HeartModelUtils:
                 return
             target_coord = av_coord
 
-        septum_point_ids = np.unique(np.ravel(model.mesh.tetrahedrons[model.septum._element_ids]))
+        septum_point_ids = np.unique(
+            np.ravel(model.mesh.tetrahedrons[model.septum.get_element_ids(model.mesh)])
+        )
 
         # remove nodes on surface, to make sure His bundle nodes are inside of septum
         septum_point_ids = np.setdiff1d(

--- a/src/ansys/health/heart/models_utils.py
+++ b/src/ansys/health/heart/models_utils.py
@@ -181,7 +181,7 @@ class HeartModelUtils:
                 return
             target_coord = av_coord
 
-        septum_point_ids = np.unique(np.ravel(model.mesh.tetrahedrons[model.septum.element_ids]))
+        septum_point_ids = np.unique(np.ravel(model.mesh.tetrahedrons[model.septum._element_ids]))
 
         # remove nodes on surface, to make sure His bundle nodes are inside of septum
         septum_point_ids = np.setdiff1d(

--- a/src/ansys/health/heart/objects.py
+++ b/src/ansys/health/heart/objects.py
@@ -581,6 +581,13 @@ class Mesh(pv.UnstructuredGrid):
             return None
 
     @property
+    def _unused_volume_id(self) -> np.ndarray:
+        """Get unused volume ID."""
+        if self.volume_ids is None:
+            return 1
+        return np.max(self.volume_ids) + 1
+
+    @property
     def volume_names(self) -> List[str]:
         """List of volume names."""
         return [v for k, v in self._volume_id_to_name.items()]

--- a/src/ansys/health/heart/parts.py
+++ b/src/ansys/health/heart/parts.py
@@ -85,7 +85,7 @@ class Part:
         """Material ID associated with the part."""
         self._part_type: _PartType = part_type
         """Type of the part."""
-        self.element_ids: np.ndarray = np.empty((0, 4), dtype=int)
+        self._element_ids: np.ndarray = np.empty((0, 4), dtype=int)
         """Array holding element IDs that make up the part."""
         self.points: list[Point] = []
         """Points of interest belonging to the part."""

--- a/src/ansys/health/heart/parts.py
+++ b/src/ansys/health/heart/parts.py
@@ -81,7 +81,10 @@ class Part:
         """Get element IDs that make up the part."""
         if mesh is None:
             LOGGER.error("Mesh is not provided to get element IDs.")
-            return np.empty((0, 4), dtype=int)
+            return np.empty((0,), dtype=int)
+        if self.pid is None:
+            LOGGER.error("Part ID is not set. Cannot get element IDs.")
+            return np.empty((0,), dtype=int)
         return np.argwhere(mesh.cell_data["_volume-id"] == self.pid).flatten()
 
     @property

--- a/src/ansys/health/heart/parts.py
+++ b/src/ansys/health/heart/parts.py
@@ -28,11 +28,12 @@ heart structures.
 
 from enum import Enum
 
+from deprecated import deprecated
 import numpy as np
 import yaml
 
 from ansys.health.heart import LOG as LOGGER
-from ansys.health.heart.objects import Cap, Cavity, Point, SurfaceMesh
+from ansys.health.heart.objects import Cap, Cavity, Mesh, Point, SurfaceMesh
 from ansys.health.heart.settings.material.ep_material import EPMaterial
 from ansys.health.heart.settings.material.material import MechanicalMaterialModel
 
@@ -75,6 +76,19 @@ class Part:
                 return point
         LOGGER.error("Cannot find point {0:s}.".format(pointname))
         return None
+
+    def get_element_ids(self, mesh: Mesh = None) -> np.ndarray:
+        """Get element IDs that make up the part."""
+        if mesh is None:
+            LOGGER.error("Mesh is not provided to get element IDs.")
+            return np.empty((0, 4), dtype=int)
+        return np.argwhere(mesh.cell_data["_volume-id"] == self.pid).flatten()
+
+    @property
+    @deprecated("`element_ids` as an attribute is deprecated. Use `get_element_ids` instead.")
+    def element_ids(self) -> np.ndarray:
+        """Get element IDs that make up the part."""
+        return self._element_ids
 
     def __init__(self, name: str = None, part_type: _PartType = _PartType.UNDEFINED) -> None:
         self.name: str = name

--- a/src/ansys/health/heart/parts.py
+++ b/src/ansys/health/heart/parts.py
@@ -78,13 +78,30 @@ class Part:
         return None
 
     def get_element_ids(self, mesh: Mesh = None) -> np.ndarray:
-        """Get element IDs that make up the part."""
+        """Get element IDs that make up the part.
+
+        Parameters
+        ----------
+        mesh : Mesh, default: None
+            The mesh object where to get the element IDs from.
+
+        Returns
+        -------
+        np.ndarray
+            Array of element IDs that make up the part.
+        """
         if mesh is None:
             LOGGER.error("Mesh is not provided to get element IDs.")
             return np.empty((0,), dtype=int)
+
         if self.pid is None:
             LOGGER.error("Part ID is not set. Cannot get element IDs.")
             return np.empty((0,), dtype=int)
+
+        if "_volume-id" not in mesh.cell_data.keys():
+            LOGGER.error("Mesh does not contain '_volume-id' cell data.")
+            return np.empty((0,), dtype=int)
+
         return np.argwhere(mesh.cell_data["_volume-id"] == self.pid).flatten()
 
     @property

--- a/src/ansys/health/heart/parts.py
+++ b/src/ansys/health/heart/parts.py
@@ -105,10 +105,13 @@ class Part:
         return np.argwhere(mesh.cell_data["_volume-id"] == self.pid).flatten()
 
     @property
-    @deprecated("`element_ids` as an attribute is deprecated. Use `get_element_ids` instead.")
+    @deprecated(
+        """`element_ids` as an attribute is deprecated. Use `part.get_element_ids(mesh)` instead.
+        To modify element IDs of a part use the `_volume-id` cell data of the mesh object.""",
+    )
     def element_ids(self) -> np.ndarray:
         """Get element IDs that make up the part."""
-        return self._element_ids
+        return None
 
     def __init__(self, name: str = None, part_type: _PartType = _PartType.UNDEFINED) -> None:
         self.name: str = name
@@ -119,8 +122,6 @@ class Part:
         """Material ID associated with the part."""
         self._part_type: _PartType = part_type
         """Type of the part."""
-        self._element_ids: np.ndarray = np.empty((0, 4), dtype=int)
-        """Array holding element IDs that make up the part."""
         self.points: list[Point] = []
         """Points of interest belonging to the part."""
 

--- a/src/ansys/health/heart/utils/landmark_utils.py
+++ b/src/ansys/health/heart/utils/landmark_utils.py
@@ -111,9 +111,14 @@ def compute_aha17(
 
     # get lv elements
     try:
-        ele_ids = np.hstack((model.left_ventricle._element_ids, model.septum._element_ids))
+        ele_ids = np.hstack(
+            (
+                model.left_ventricle.get_element_ids(model.mesh),
+                model.septum.get_element_ids(model.mesh),
+            )
+        )
     except AttributeError:
-        ele_ids = np.hstack(model.left_ventricle._element_ids)
+        ele_ids = np.hstack(model.left_ventricle.get_element_ids(model.mesh))
 
     # element's center
     elem_center = np.mean(model.mesh.points[model.mesh.tetrahedrons[ele_ids]], axis=1)

--- a/src/ansys/health/heart/utils/landmark_utils.py
+++ b/src/ansys/health/heart/utils/landmark_utils.py
@@ -111,9 +111,9 @@ def compute_aha17(
 
     # get lv elements
     try:
-        ele_ids = np.hstack((model.left_ventricle.element_ids, model.septum.element_ids))
+        ele_ids = np.hstack((model.left_ventricle._element_ids, model.septum._element_ids))
     except AttributeError:
-        ele_ids = np.hstack(model.left_ventricle.element_ids)
+        ele_ids = np.hstack(model.left_ventricle._element_ids)
 
     # element's center
     elem_center = np.mean(model.mesh.points[model.mesh.tetrahedrons[ele_ids]], axis=1)

--- a/src/ansys/health/heart/utils/misc.py
+++ b/src/ansys/health/heart/utils/misc.py
@@ -91,7 +91,7 @@ def model_summary(model: HeartModel, attributes: list = None) -> dict:
     sum_dict["CAVITIES"] = {}
     for ii, part in enumerate(model.parts):
         sum_dict["PARTS"][part.name] = {}
-        sum_dict["PARTS"][part.name]["num_tets"] = len(part.element_ids)
+        sum_dict["PARTS"][part.name]["num_tets"] = len(part._element_ids)
 
         sum_dict["PARTS"][part.name]["SURFACES"] = {}
         sum_dict["PARTS"][part.name]["CAPS"] = {}

--- a/src/ansys/health/heart/utils/misc.py
+++ b/src/ansys/health/heart/utils/misc.py
@@ -91,7 +91,7 @@ def model_summary(model: HeartModel, attributes: list = None) -> dict:
     sum_dict["CAVITIES"] = {}
     for ii, part in enumerate(model.parts):
         sum_dict["PARTS"][part.name] = {}
-        sum_dict["PARTS"][part.name]["num_tets"] = len(part._element_ids)
+        sum_dict["PARTS"][part.name]["num_tets"] = len(part.get_element_ids(model.mesh))
 
         sum_dict["PARTS"][part.name]["SURFACES"] = {}
         sum_dict["PARTS"][part.name]["CAPS"] = {}

--- a/src/ansys/health/heart/writer/base_writer.py
+++ b/src/ansys/health/heart/writer/base_writer.py
@@ -796,7 +796,7 @@ class FiberGenerationDynaWriter(BaseDynaWriter):
             parts = ventricles
         material_settings = self.settings.electrophysiology.material
         for part in parts:
-            # element_ids = part._element_ids
+            # element_ids = part.get_element_ids(self.model.mesh)
             # em_mat_id = self.get_unique_mat_id()
             em_mat_id = part.mid  # Needs to match material id used in update_parts_db
             self.kw_database.material.extend(

--- a/src/ansys/health/heart/writer/base_writer.py
+++ b/src/ansys/health/heart/writer/base_writer.py
@@ -277,7 +277,7 @@ class BaseDynaWriter:
         node_ids = surface.global_node_ids_triangles
 
         for part in self.model.parts:
-            element_ids = np.append(element_ids, part._element_ids)
+            element_ids = np.append(element_ids, part.get_element_ids(self.model.mesh))
 
         element_ids = np.unique(element_ids)
         active_tets = self.model.mesh.tetrahedrons[element_ids]
@@ -632,7 +632,9 @@ class BaseDynaWriter:
             )
             #! This only works since tetrahedrons are at start of model.mesh, and surface
             #! cells are added behind these tetrahedrons.
-            tetrahedrons = self.model.mesh.tetrahedrons[part._element_ids, :] + 1
+            tetrahedrons = (
+                self.model.mesh.tetrahedrons[part.get_element_ids(self.model.mesh), :] + 1
+            )
             num_elements = tetrahedrons.shape[0]
 
             # element_ids = np.arange(1, num_elements + 1, 1) + solid_element_count
@@ -643,7 +645,7 @@ class BaseDynaWriter:
                 kw_elements = keywords.ElementSolid()
                 elements = pd.DataFrame(
                     {
-                        "eid": part._element_ids + 1,
+                        "eid": part.get_element_ids(self.model.mesh) + 1,
                         "pid": part_ids,
                         "n1": tetrahedrons[:, 0],
                         "n2": tetrahedrons[:, 1],
@@ -658,8 +660,8 @@ class BaseDynaWriter:
                 kw_elements.elements = elements
 
             elif part_add_fibers:
-                fiber = self.volume_mesh.cell_data["fiber"][part._element_ids]
-                sheet = self.volume_mesh.cell_data["sheet"][part._element_ids]
+                fiber = self.volume_mesh.cell_data["fiber"][part.get_element_ids(self.model.mesh)]
+                sheet = self.volume_mesh.cell_data["sheet"][part.get_element_ids(self.model.mesh)]
 
                 # normalize fiber and sheet directions:
                 # norm = np.linalg.norm(fiber, axis=1)
@@ -671,7 +673,7 @@ class BaseDynaWriter:
                     elements=tetrahedrons,
                     a_vec=fiber,
                     d_vec=sheet,
-                    e_id=part._element_ids + 1,
+                    e_id=part.get_element_ids(self.model.mesh) + 1,
                     part_id=part_ids,
                     element_type="tetra",
                 )
@@ -716,7 +718,7 @@ class FiberGenerationDynaWriter(BaseDynaWriter):
             #! of the mesh (file)! E.g. check self.mesh.celltypes to make sure this is the case!
             tet_ids = np.empty((0), dtype=int)
             for part in parts:
-                tet_ids = np.append(tet_ids, part._element_ids)
+                tet_ids = np.append(tet_ids, part.get_element_ids(self.model.mesh))
                 tets = self.model.mesh.tetrahedrons[tet_ids, :]
             nids = np.unique(tets)
 
@@ -762,7 +764,7 @@ class FiberGenerationDynaWriter(BaseDynaWriter):
 
         tet_ids = np.empty((0), dtype=int)
         for part in parts:
-            tet_ids = np.append(tet_ids, part._element_ids)
+            tet_ids = np.append(tet_ids, part.get_element_ids(self.model.mesh))
             tets = self.model.mesh.tetrahedrons[tet_ids, :]
         nids = np.unique(tets)
 
@@ -904,7 +906,9 @@ class FiberGenerationDynaWriter(BaseDynaWriter):
             parts = ventricles
 
         for part in parts:
-            tet_ids_ventricles = np.append(tet_ids_ventricles, part._element_ids)
+            tet_ids_ventricles = np.append(
+                tet_ids_ventricles, part.get_element_ids(self.model.mesh)
+            )
 
         tetra_ventricles = self.model.mesh.tetrahedrons[tet_ids_ventricles, :]
 

--- a/src/ansys/health/heart/writer/base_writer.py
+++ b/src/ansys/health/heart/writer/base_writer.py
@@ -277,7 +277,7 @@ class BaseDynaWriter:
         node_ids = surface.global_node_ids_triangles
 
         for part in self.model.parts:
-            element_ids = np.append(element_ids, part.element_ids)
+            element_ids = np.append(element_ids, part._element_ids)
 
         element_ids = np.unique(element_ids)
         active_tets = self.model.mesh.tetrahedrons[element_ids]
@@ -632,7 +632,7 @@ class BaseDynaWriter:
             )
             #! This only works since tetrahedrons are at start of model.mesh, and surface
             #! cells are added behind these tetrahedrons.
-            tetrahedrons = self.model.mesh.tetrahedrons[part.element_ids, :] + 1
+            tetrahedrons = self.model.mesh.tetrahedrons[part._element_ids, :] + 1
             num_elements = tetrahedrons.shape[0]
 
             # element_ids = np.arange(1, num_elements + 1, 1) + solid_element_count
@@ -643,7 +643,7 @@ class BaseDynaWriter:
                 kw_elements = keywords.ElementSolid()
                 elements = pd.DataFrame(
                     {
-                        "eid": part.element_ids + 1,
+                        "eid": part._element_ids + 1,
                         "pid": part_ids,
                         "n1": tetrahedrons[:, 0],
                         "n2": tetrahedrons[:, 1],
@@ -658,8 +658,8 @@ class BaseDynaWriter:
                 kw_elements.elements = elements
 
             elif part_add_fibers:
-                fiber = self.volume_mesh.cell_data["fiber"][part.element_ids]
-                sheet = self.volume_mesh.cell_data["sheet"][part.element_ids]
+                fiber = self.volume_mesh.cell_data["fiber"][part._element_ids]
+                sheet = self.volume_mesh.cell_data["sheet"][part._element_ids]
 
                 # normalize fiber and sheet directions:
                 # norm = np.linalg.norm(fiber, axis=1)
@@ -671,7 +671,7 @@ class BaseDynaWriter:
                     elements=tetrahedrons,
                     a_vec=fiber,
                     d_vec=sheet,
-                    e_id=part.element_ids + 1,
+                    e_id=part._element_ids + 1,
                     part_id=part_ids,
                     element_type="tetra",
                 )
@@ -716,7 +716,7 @@ class FiberGenerationDynaWriter(BaseDynaWriter):
             #! of the mesh (file)! E.g. check self.mesh.celltypes to make sure this is the case!
             tet_ids = np.empty((0), dtype=int)
             for part in parts:
-                tet_ids = np.append(tet_ids, part.element_ids)
+                tet_ids = np.append(tet_ids, part._element_ids)
                 tets = self.model.mesh.tetrahedrons[tet_ids, :]
             nids = np.unique(tets)
 
@@ -762,7 +762,7 @@ class FiberGenerationDynaWriter(BaseDynaWriter):
 
         tet_ids = np.empty((0), dtype=int)
         for part in parts:
-            tet_ids = np.append(tet_ids, part.element_ids)
+            tet_ids = np.append(tet_ids, part._element_ids)
             tets = self.model.mesh.tetrahedrons[tet_ids, :]
         nids = np.unique(tets)
 
@@ -794,7 +794,7 @@ class FiberGenerationDynaWriter(BaseDynaWriter):
             parts = ventricles
         material_settings = self.settings.electrophysiology.material
         for part in parts:
-            # element_ids = part.element_ids
+            # element_ids = part._element_ids
             # em_mat_id = self.get_unique_mat_id()
             em_mat_id = part.mid  # Needs to match material id used in update_parts_db
             self.kw_database.material.extend(
@@ -904,7 +904,7 @@ class FiberGenerationDynaWriter(BaseDynaWriter):
             parts = ventricles
 
         for part in parts:
-            tet_ids_ventricles = np.append(tet_ids_ventricles, part.element_ids)
+            tet_ids_ventricles = np.append(tet_ids_ventricles, part._element_ids)
 
         tetra_ventricles = self.model.mesh.tetrahedrons[tet_ids_ventricles, :]
 

--- a/src/ansys/health/heart/writer/laplace_writer.py
+++ b/src/ansys/health/heart/writer/laplace_writer.py
@@ -92,11 +92,11 @@ class LaplaceWriter(BaseDynaWriter):
         if self.type == "uvc" or self.type == "D-RBM":
             elems_to_keep = []
             if isinstance(self.model, LeftVentricle):
-                elems_to_keep.extend(model.left_ventricle.element_ids)
+                elems_to_keep.extend(model.left_ventricle._element_ids)
             else:
-                elems_to_keep.extend(model.left_ventricle.element_ids)
-                elems_to_keep.extend(model.right_ventricle.element_ids)
-                elems_to_keep.extend(model.septum.element_ids)
+                elems_to_keep.extend(model.left_ventricle._element_ids)
+                elems_to_keep.extend(model.right_ventricle._element_ids)
+                elems_to_keep.extend(model.septum._element_ids)
 
             # model.mesh.clear_data()
             model.mesh["cell_ids"] = np.arange(0, model.mesh.n_cells, dtype=int)
@@ -110,7 +110,7 @@ class LaplaceWriter(BaseDynaWriter):
             model.mesh["cell_ids"] = np.arange(0, model.mesh.n_cells, dtype=int)
             model.mesh["point_ids"] = np.arange(0, model.mesh.n_points, dtype=int)
 
-            self.target = model.mesh.extract_cells(model.parts[0].element_ids)
+            self.target = model.mesh.extract_cells(model.parts[0]._element_ids)
 
     def _update_ra_top_nodeset(self, atrium: pv.UnstructuredGrid) -> None:
         """

--- a/src/ansys/health/heart/writer/laplace_writer.py
+++ b/src/ansys/health/heart/writer/laplace_writer.py
@@ -92,11 +92,11 @@ class LaplaceWriter(BaseDynaWriter):
         if self.type == "uvc" or self.type == "D-RBM":
             elems_to_keep = []
             if isinstance(self.model, LeftVentricle):
-                elems_to_keep.extend(model.left_ventricle._element_ids)
+                elems_to_keep.extend(model.left_ventricle.get_element_ids(model.mesh))
             else:
-                elems_to_keep.extend(model.left_ventricle._element_ids)
-                elems_to_keep.extend(model.right_ventricle._element_ids)
-                elems_to_keep.extend(model.septum._element_ids)
+                elems_to_keep.extend(model.left_ventricle.get_element_ids(model.mesh))
+                elems_to_keep.extend(model.right_ventricle.get_element_ids(model.mesh))
+                elems_to_keep.extend(model.septum.get_element_ids(model.mesh))
 
             # model.mesh.clear_data()
             model.mesh["cell_ids"] = np.arange(0, model.mesh.n_cells, dtype=int)
@@ -110,7 +110,7 @@ class LaplaceWriter(BaseDynaWriter):
             model.mesh["cell_ids"] = np.arange(0, model.mesh.n_cells, dtype=int)
             model.mesh["point_ids"] = np.arange(0, model.mesh.n_points, dtype=int)
 
-            self.target = model.mesh.extract_cells(model.parts[0]._element_ids)
+            self.target = model.mesh.extract_cells(model.parts[0].get_element_ids(model.mesh))
 
     def _update_ra_top_nodeset(self, atrium: pv.UnstructuredGrid) -> None:
         """

--- a/tests/heart/test_heart_model.py
+++ b/tests/heart/test_heart_model.py
@@ -172,9 +172,15 @@ def test_load_from_mesh():
 
         assert model.part_names == list(part_info.keys())
 
-        assert model.left_ventricle._element_ids.shape[0] == examples.load_tetbeam().n_cells
-        assert model.right_ventricle._element_ids.shape[0] == examples.load_tetbeam().n_cells
-        assert model.septum._element_ids.shape[0] == examples.load_tetbeam().n_cells
+        assert (
+            model.left_ventricle.get_element_ids(model.mesh).shape[0]
+            == examples.load_tetbeam().n_cells
+        )
+        assert (
+            model.right_ventricle.get_element_ids(model.mesh).shape[0]
+            == examples.load_tetbeam().n_cells
+        )
+        assert model.septum.get_element_ids(model.mesh).shape[0] == examples.load_tetbeam().n_cells
 
         assert model.left_ventricle.endocardium.n_cells == pv.Sphere().n_cells
         assert model.left_ventricle.endocardium.n_points == pv.Sphere().n_points

--- a/tests/heart/test_heart_model.py
+++ b/tests/heart/test_heart_model.py
@@ -224,7 +224,6 @@ def test_create_stiff_ventricle_base():
     mesh1.add_volume(mesh, id=1, name="Left ventricle")
     model.mesh = mesh1
     model.left_ventricle.pid = 1.0
-    model.left_ventricle._element_ids = model.left_ventricle.get_element_ids(mesh1)
 
     part = model.create_stiff_ventricle_base()
 

--- a/tests/heart/test_heart_model.py
+++ b/tests/heart/test_heart_model.py
@@ -224,6 +224,10 @@ def test_create_stiff_ventricle_base():
     model.mesh = mesh1
     model.left_ventricle._element_ids = np.arange(0, model.mesh.n_cells)
 
+    mesh1._unused_volume_id
+
     part = model.create_stiff_ventricle_base()
-    assert len(part._element_ids) == 20
-    assert np.all(part._element_ids == np.arange(180, 200))
+
+    part_element_ids = part.get_element_ids(mesh1)
+    assert len(part_element_ids) == 20
+    assert np.all(part_element_ids == np.arange(180, 200))

--- a/tests/heart/test_heart_model.py
+++ b/tests/heart/test_heart_model.py
@@ -172,9 +172,9 @@ def test_load_from_mesh():
 
         assert model.part_names == list(part_info.keys())
 
-        assert model.left_ventricle.element_ids.shape[0] == examples.load_tetbeam().n_cells
-        assert model.right_ventricle.element_ids.shape[0] == examples.load_tetbeam().n_cells
-        assert model.septum.element_ids.shape[0] == examples.load_tetbeam().n_cells
+        assert model.left_ventricle._element_ids.shape[0] == examples.load_tetbeam().n_cells
+        assert model.right_ventricle._element_ids.shape[0] == examples.load_tetbeam().n_cells
+        assert model.septum._element_ids.shape[0] == examples.load_tetbeam().n_cells
 
         assert model.left_ventricle.endocardium.n_cells == pv.Sphere().n_cells
         assert model.left_ventricle.endocardium.n_points == pv.Sphere().n_points
@@ -222,8 +222,8 @@ def test_create_stiff_ventricle_base():
     mesh1 = Mesh()
     mesh1.add_volume(mesh, id=1, name="Left ventricle")
     model.mesh = mesh1
-    model.left_ventricle.element_ids = np.arange(0, model.mesh.n_cells)
+    model.left_ventricle._element_ids = np.arange(0, model.mesh.n_cells)
 
     part = model.create_stiff_ventricle_base()
-    assert len(part.element_ids) == 20
-    assert np.all(part.element_ids == np.arange(180, 200))
+    assert len(part._element_ids) == 20
+    assert np.all(part._element_ids == np.arange(180, 200))

--- a/tests/heart/test_heart_model.py
+++ b/tests/heart/test_heart_model.py
@@ -229,7 +229,7 @@ def test_create_stiff_ventricle_base():
     mesh1 = Mesh()
     mesh1.add_volume(mesh, id=1, name="Left ventricle")
     model.mesh = mesh1
-    model.left_ventricle.pid = 1.0
+    model.left_ventricle.pid = 1
 
     part = model.create_stiff_ventricle_base()
 

--- a/tests/heart/test_heart_model.py
+++ b/tests/heart/test_heart_model.py
@@ -218,16 +218,18 @@ def test_create_stiff_ventricle_base():
     mesh = examples.load_tetbeam()
     mesh.cell_data["_volume-id"] = 1
     mesh.point_data["apico-basal"] = mesh.points[:, 2] / 5
+    total_num_cells = mesh.n_cells
 
     mesh1 = Mesh()
     mesh1.add_volume(mesh, id=1, name="Left ventricle")
     model.mesh = mesh1
-    model.left_ventricle._element_ids = np.arange(0, model.mesh.n_cells)
-
-    mesh1._unused_volume_id
+    model.left_ventricle.pid = 1.0
+    model.left_ventricle._element_ids = model.left_ventricle.get_element_ids(mesh1)
 
     part = model.create_stiff_ventricle_base()
 
-    part_element_ids = part.get_element_ids(mesh1)
+    part_element_ids = part.get_element_ids(model.mesh)
     assert len(part_element_ids) == 20
     assert np.all(part_element_ids == np.arange(180, 200))
+    # Check whether the left ventricle part has the correct number of cells
+    assert len(model.left_ventricle.get_element_ids(model.mesh)) == total_num_cells - 20

--- a/tests/heart/test_heart_model_plot.py
+++ b/tests/heart/test_heart_model_plot.py
@@ -73,8 +73,8 @@ def test_heart_model_plot_mesh(_mock_input):
 def test_heart_model_plot_part(_mock_input):
     """Test plotting a part."""
     mock_biventricle, mock_show = _mock_input
-    mock_part = mock.Mock(Part)
-    mock_part._element_ids = np.array([0, 1, 2, 3, 4])
+    mock_part = Part("mock_part")
+    mock_part.pid = 1
     mock_biventricle.plot_part(mock_part)
     mock_show.assert_called_once()
 

--- a/tests/heart/test_heart_model_plot.py
+++ b/tests/heart/test_heart_model_plot.py
@@ -74,7 +74,7 @@ def test_heart_model_plot_part(_mock_input):
     """Test plotting a part."""
     mock_biventricle, mock_show = _mock_input
     mock_part = mock.Mock(Part)
-    mock_part.element_ids = np.array([0, 1, 2, 3, 4])
+    mock_part._element_ids = np.array([0, 1, 2, 3, 4])
     mock_biventricle.plot_part(mock_part)
     mock_show.assert_called_once()
 

--- a/tests/heart/test_parts.py
+++ b/tests/heart/test_parts.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import numpy as np
 import pytest
 import pyvista as pv
 
@@ -88,3 +89,44 @@ def test_part_get_info_with_data():
     assert info["Part1"]["surfaces"] == {"tube1": 10, "tube2": 11}
     assert info["Part1"]["caps"] == {"cap1": 100, "cap2": 101}
     assert info["Part1"]["cavity"] == {"cavity1": 1000}
+
+
+class DummyMesh:
+    """Minimal mesh mock for testing get_element_ids."""
+
+    def __init__(self, volume_ids):
+        # Simulate mesh.cell_data["_volume-id"] as a numpy array
+        self.cell_data = {"_volume-id": np.array(volume_ids)}
+
+
+def test_get_element_ids_returns_correct_indices():
+    # Setup: mesh with _volume-id array, and a part with a specific pid
+    volume_ids = [1, 2, 2, 3, 2, 1]
+    mesh = DummyMesh(volume_ids)
+    part = Part("TestPart")
+
+    part.pid = 2
+    # Should return indices where _volume-id == 2
+    result = part.get_element_ids(mesh)
+    expected = np.argwhere(np.array(volume_ids) == 2).flatten()
+    assert np.array_equal(result, expected)
+
+
+def test_get_element_ids_returns_empty_if_mesh_none(caplog):
+    part = Part("TestPart")
+    part.pid = 1
+    result = part.get_element_ids(None)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (0, 4)
+    # Check error log message
+    assert any("Mesh is not provided to get element IDs." in m for m in caplog.text.splitlines())
+
+
+def test_get_element_ids_returns_empty_if_pid_not_found():
+    volume_ids = [1, 1, 1]
+    mesh = DummyMesh(volume_ids)
+    part = Part("TestPart")
+    part.pid = 99  # pid not in volume_ids
+    # Should return empty array, but shape will be (0,) due to np.argwhere
+    result = part.get_element_ids(mesh)
+    assert result.shape == (0,)

--- a/tests/heart/test_parts.py
+++ b/tests/heart/test_parts.py
@@ -91,7 +91,7 @@ def test_part_get_info_with_data():
     assert info["Part1"]["cavity"] == {"cavity1": 1000}
 
 
-class DummyMesh:
+class MockMesh:
     """Minimal mesh mock for testing get_element_ids."""
 
     def __init__(self, volume_ids):
@@ -102,7 +102,7 @@ class DummyMesh:
 def test_get_element_ids_returns_correct_indices():
     # Setup: mesh with _volume-id array, and a part with a specific pid
     volume_ids = [1, 2, 2, 3, 2, 1]
-    mesh = DummyMesh(volume_ids)
+    mesh = MockMesh(volume_ids)
     part = Part("TestPart")
 
     part.pid = 2
@@ -118,13 +118,12 @@ def test_get_element_ids_returns_empty_if_mesh_none(caplog):
     result = part.get_element_ids(None)
     assert isinstance(result, np.ndarray)
     assert result.shape == (0, 4)
-    # Check error log message
     assert any("Mesh is not provided to get element IDs." in m for m in caplog.text.splitlines())
 
 
 def test_get_element_ids_returns_empty_if_pid_not_found():
     volume_ids = [1, 1, 1]
-    mesh = DummyMesh(volume_ids)
+    mesh = MockMesh(volume_ids)
     part = Part("TestPart")
     part.pid = 99  # pid not in volume_ids
     # Should return empty array, but shape will be (0,) due to np.argwhere

--- a/tests/heart/test_parts.py
+++ b/tests/heart/test_parts.py
@@ -24,7 +24,7 @@ import numpy as np
 import pytest
 import pyvista as pv
 
-from ansys.health.heart.objects import Cap, Cavity, SurfaceMesh
+from ansys.health.heart.objects import Cap, Cavity, Mesh, SurfaceMesh
 from ansys.health.heart.parts import (
     Artery,
     Atrium,
@@ -91,29 +91,48 @@ def test_part_get_info_with_data():
     assert info["Part1"]["cavity"] == {"cavity1": 1000}
 
 
-# TODO: Replace with instance of objects.Mesh
-class MockMesh:
-    """Minimal mesh mock for testing get_element_ids."""
+def _get_mock_mesh():
+    """Create a mock mesh with two tetrahedra and a _volume-id array."""
+    points = np.array(
+        [
+            [0, 0, 0],
+            [1, 0, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+            [1, 1, 0],
+            [1, 0, 1],
+        ]
+    )
+    # Two tetrahedra:
+    cells = np.hstack(
+        [
+            [4, 0, 1, 2, 3],
+            [4, 1, 2, 4, 5],
+        ]
+    )
+    celltypes = np.array([pv.CellType.TETRA, pv.CellType.TETRA])
+    grid = pv.UnstructuredGrid(cells, celltypes, points)
 
-    def __init__(self, volume_ids):
-        # Simulate mesh.cell_data["_volume-id"] as a numpy array
-        self.cell_data = {"_volume-id": np.array(volume_ids)}
+    # Mock volume IDs
+    grid.cell_data["_volume-id"] = np.array([1, 2])
+    return Mesh(grid)
 
 
 def test_get_element_ids_returns_correct_indices():
+    """Test get_element_ids returns correct indices based on _volume-id."""
     # Setup: mesh with _volume-id array, and a part with a specific pid
-    volume_ids = [1, 2, 2, 3, 2, 1]
-    mesh = MockMesh(volume_ids)
+    mesh = _get_mock_mesh()
     part = Part("TestPart")
 
     part.pid = 2
     # Should return indices where _volume-id == 2
     result = part.get_element_ids(mesh)
-    expected = np.argwhere(np.array(volume_ids) == 2).flatten()
+    expected = np.argwhere(np.array(mesh.volume_ids) == 2).flatten()
     assert np.array_equal(result, expected)
 
 
 def test_get_element_ids_returns_empty_if_mesh_none(caplog):
+    """Test get_element_ids returns empty array if mesh is None."""
     part = Part("TestPart")
     part.pid = 1
     result = part.get_element_ids(None)
@@ -123,8 +142,8 @@ def test_get_element_ids_returns_empty_if_mesh_none(caplog):
 
 
 def test_get_element_ids_returns_empty_if_pid_not_found():
-    volume_ids = [1, 1, 1]
-    mesh = MockMesh(volume_ids)
+    """Test get_element_ids returns empty array if pid is not found in volume_ids."""
+    mesh = _get_mock_mesh()
     part = Part("TestPart")
     part.pid = 99  # pid not in volume_ids
     # Should return empty array, but shape will be (0,) due to np.argwhere
@@ -134,16 +153,9 @@ def test_get_element_ids_returns_empty_if_pid_not_found():
 
 def test_get_element_ids_returns_empty_if_volume_id_missing(caplog):
     """Test get_element_ids returns empty array and logs error if '_volume-id' is missing."""
-    import pyvista as pv
-
-    from ansys.health.heart.objects import Mesh
-
-    # Create a minimal mesh without '_volume-id'
-    points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
-    cells = np.hstack([[4, 0, 1, 2, 3]])
-    celltypes = np.array([pv.CellType.TETRA])
-    grid = pv.UnstructuredGrid(cells, celltypes, points)
-    mesh = Mesh(grid)
+    mesh = _get_mock_mesh()
+    # Remove '_volume-id' to simulate missing cell data
+    mesh.cell_data.remove("_volume-id")
 
     part = Part("TestPart")
     part.pid = 1

--- a/tests/heart/test_parts.py
+++ b/tests/heart/test_parts.py
@@ -91,6 +91,7 @@ def test_part_get_info_with_data():
     assert info["Part1"]["cavity"] == {"cavity1": 1000}
 
 
+# TODO: Replace with instance of objects.Mesh
 class MockMesh:
     """Minimal mesh mock for testing get_element_ids."""
 
@@ -117,7 +118,7 @@ def test_get_element_ids_returns_empty_if_mesh_none(caplog):
     part.pid = 1
     result = part.get_element_ids(None)
     assert isinstance(result, np.ndarray)
-    assert result.shape == (0, 4)
+    assert result.shape == (0,)
     assert any("Mesh is not provided to get element IDs." in m for m in caplog.text.splitlines())
 
 

--- a/tests/heart/test_parts.py
+++ b/tests/heart/test_parts.py
@@ -130,3 +130,27 @@ def test_get_element_ids_returns_empty_if_pid_not_found():
     # Should return empty array, but shape will be (0,) due to np.argwhere
     result = part.get_element_ids(mesh)
     assert result.shape == (0,)
+
+
+def test_get_element_ids_returns_empty_if_volume_id_missing(caplog):
+    """Test get_element_ids returns empty array and logs error if '_volume-id' is missing."""
+    import pyvista as pv
+
+    from ansys.health.heart.objects import Mesh
+
+    # Create a minimal mesh without '_volume-id'
+    points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    cells = np.hstack([[4, 0, 1, 2, 3]])
+    celltypes = np.array([pv.CellType.TETRA])
+    grid = pv.UnstructuredGrid(cells, celltypes, points)
+    mesh = Mesh(grid)
+
+    part = Part("TestPart")
+    part.pid = 1
+
+    result = part.get_element_ids(mesh)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (0,)
+    assert any(
+        "Mesh does not contain '_volume-id' cell data." in m for m in caplog.text.splitlines()
+    )

--- a/tests/heart/writer/test_writer001.py
+++ b/tests/heart/writer/test_writer001.py
@@ -49,7 +49,7 @@ def get_test_model():
     celltypes = [pv.CellType.TETRA] * 2
 
     model.mesh = Mesh(cells, celltypes, points)
-    model.left_ventricle.element_ids = np.array([0, 1], dtype=int)
+    model.left_ventricle._element_ids = np.array([0, 1], dtype=int)
 
     model.left_ventricle.endocardium.triangles = np.array([[1, 2, 3]], dtype=int)
     model.left_ventricle.endocardium.points = model.mesh.points

--- a/tests/heart/writer/test_writer001.py
+++ b/tests/heart/writer/test_writer001.py
@@ -52,7 +52,6 @@ def get_test_model():
     model.mesh.cell_data["_volume-id"] = 1.0
     model.mesh._volume_id_to_name["_volume-id"] = "left-ventricle"
     model.left_ventricle.pid = 1.0
-    model.left_ventricle._element_ids = model.left_ventricle.get_element_ids(model.mesh)
 
     model.left_ventricle.endocardium.triangles = np.array([[1, 2, 3]], dtype=int)
     model.left_ventricle.endocardium.points = model.mesh.points

--- a/tests/heart/writer/test_writer001.py
+++ b/tests/heart/writer/test_writer001.py
@@ -49,9 +49,9 @@ def get_test_model():
     celltypes = [pv.CellType.TETRA] * 2
 
     model.mesh = Mesh(cells, celltypes, points)
-    model.mesh.cell_data["_volume-id"] = 1.0
+    model.mesh.cell_data["_volume-id"] = 1
     model.mesh._volume_id_to_name["_volume-id"] = "left-ventricle"
-    model.left_ventricle.pid = 1.0
+    model.left_ventricle.pid = 1
 
     model.left_ventricle.endocardium.triangles = np.array([[1, 2, 3]], dtype=int)
     model.left_ventricle.endocardium.points = model.mesh.points

--- a/tests/heart/writer/test_writer001.py
+++ b/tests/heart/writer/test_writer001.py
@@ -49,7 +49,10 @@ def get_test_model():
     celltypes = [pv.CellType.TETRA] * 2
 
     model.mesh = Mesh(cells, celltypes, points)
-    model.left_ventricle._element_ids = np.array([0, 1], dtype=int)
+    model.mesh.cell_data["_volume-id"] = 1.0
+    model.mesh._volume_id_to_name["_volume-id"] = "left-ventricle"
+    model.left_ventricle.pid = 1.0
+    model.left_ventricle._element_ids = model.left_ventricle.get_element_ids(model.mesh)
 
     model.left_ventricle.endocardium.triangles = np.array([[1, 2, 3]], dtype=int)
     model.left_ventricle.endocardium.points = model.mesh.points


### PR DESCRIPTION
Deprecates `element_ids` as an attribute of parts. Use the `get_element_ids()` method with a `Mesh` object and the parts pid instead.

This also modifies any methods that were just modifying element_ids in the `Part` class without modifying the mesh data in `Mesh`. This avoids inconsistencies between `Part` and `Mesh`.  