### PR TITLE
fix: assign unique surface ids to cavities and patches

### DIFF
--- a/doc/source/changelog/1156.fixed.md
+++ b/doc/source/changelog/1156.fixed.md
@@ -1,0 +1,1 @@
+Assign unique surface ids to cavities and patches

--- a/src/ansys/health/heart/models.py
+++ b/src/ansys/health/heart/models.py
@@ -1253,7 +1253,9 @@ class HeartModel:
             surface_cavity = SurfaceMesh(pv.merge([surface] + [cap._mesh for cap in part.caps]))
             surface_cavity.name = surface.name
 
-            surface_cavity.id = self.mesh.get_unused_id_in_range(id_type="surface")
+            surface_cavity.id = self.mesh.get_unused_id_in_range(
+                id_type="surface", start=1, end=1000
+            )
 
             #! Force normals of cavity surface to point inward.
             surface_cavity.force_normals_inwards()

--- a/src/ansys/health/heart/models.py
+++ b/src/ansys/health/heart/models.py
@@ -1213,9 +1213,6 @@ class HeartModel:
             surface: SurfaceMesh = SurfaceMesh(pv.merge(surfaces))
             surface.name = part.name + " cavity"
 
-            # save this cavity mesh to the centralized mesh object
-            surface.id = self.mesh._unused_surface_id  # get unique ID.
-
             # Generate patches that close the surface.
             patches = vtk_utils.get_patches_with_centroid(surface)
 
@@ -1229,9 +1226,10 @@ class HeartModel:
                 cap_name = f"cap_{patch_counter}_{part.name}"
 
                 # create cap: NOTE, mostly for compatibility. Could simplify further
-                cap_mesh = SurfaceMesh(
-                    patch.clean(), name=cap_name, id=self.mesh._unused_surface_id
+                unused_id = self.mesh.get_unused_id_in_range(
+                    id_type="surface", start=1001, end=2000
                 )
+                cap_mesh = SurfaceMesh(patch.clean(), name=cap_name, id=unused_id)
 
                 # Add cap to main mesh.
                 self.mesh.add_surface(cap_mesh, id=cap_mesh.id, name=cap_name)
@@ -1255,7 +1253,7 @@ class HeartModel:
             surface_cavity = SurfaceMesh(pv.merge([surface] + [cap._mesh for cap in part.caps]))
             surface_cavity.name = surface.name
 
-            surface_cavity.id = self.mesh._unused_surface_id
+            surface_cavity.id = self.mesh.get_unused_id_in_range(id_type="surface")
 
             #! Force normals of cavity surface to point inward.
             surface_cavity.force_normals_inwards()

--- a/src/ansys/health/heart/models.py
+++ b/src/ansys/health/heart/models.py
@@ -1190,8 +1190,7 @@ class HeartModel:
     def _assign_cavities_to_parts(self) -> None:
         """Create cavities based on endocardium surfaces and cap definitions."""
         # construct cavities with endocardium and caps
-        idoffset = 1000  # TODO: need to improve id checking
-        ii = 0
+        patch_counter = 0
 
         parts_with_cavities = [p for p in self.parts if isinstance(p, anatomy.Chamber)]
 
@@ -1215,7 +1214,7 @@ class HeartModel:
             surface.name = part.name + " cavity"
 
             # save this cavity mesh to the centralized mesh object
-            surface.id = int(np.sort(self.mesh.surface_ids)[-1] + 1)  # get unique ID.
+            surface.id = self.mesh._unused_surface_id  # get unique ID.
 
             # Generate patches that close the surface.
             patches = vtk_utils.get_patches_with_centroid(surface)
@@ -1225,12 +1224,14 @@ class HeartModel:
             # TODO: Note that points come from surface, and does not contain all points in the mesh.
             # Create Cap objects with patches.
             for patch in patches:
-                ii += 1
+                patch_counter += 1
 
-                cap_name = f"cap_{ii}_{part.name}"
+                cap_name = f"cap_{patch_counter}_{part.name}"
 
                 # create cap: NOTE, mostly for compatibility. Could simplify further
-                cap_mesh = SurfaceMesh(patch.clean(), name=cap_name, id=ii + idoffset)
+                cap_mesh = SurfaceMesh(
+                    patch.clean(), name=cap_name, id=self.mesh._unused_surface_id
+                )
 
                 # Add cap to main mesh.
                 self.mesh.add_surface(cap_mesh, id=cap_mesh.id, name=cap_name)
@@ -1253,7 +1254,8 @@ class HeartModel:
             surface.cell_data["_cap_id"] = 0
             surface_cavity = SurfaceMesh(pv.merge([surface] + [cap._mesh for cap in part.caps]))
             surface_cavity.name = surface.name
-            surface_cavity.id = surface.id
+
+            surface_cavity.id = self.mesh._unused_surface_id
 
             #! Force normals of cavity surface to point inward.
             surface_cavity.force_normals_inwards()

--- a/src/ansys/health/heart/objects.py
+++ b/src/ansys/health/heart/objects.py
@@ -610,11 +610,12 @@ class Mesh(pv.UnstructuredGrid):
         if ids is None:
             return start
 
-        for ii in range(start, end + 1):
-            if ii not in ids:
-                return ii
-
-        raise ValueError(f"No unused ID found in the range {start} to {end}.")
+        # Subtract existing IDs from IDs in range to get candidate IDs
+        candidate_ids = set(range(start, end + 1)) - set(ids)
+        if candidate_ids != {}:
+            return min(candidate_ids)
+        else:
+            raise ValueError(f"No unused ID found in the range {start} to {end}.")
 
     @property
     def _unused_line_id(self) -> int:

--- a/src/ansys/health/heart/objects.py
+++ b/src/ansys/health/heart/objects.py
@@ -581,11 +581,25 @@ class Mesh(pv.UnstructuredGrid):
             return None
 
     @property
-    def _unused_volume_id(self) -> np.ndarray:
+    def _unused_volume_id(self) -> int:
         """Get unused volume ID."""
         if self.volume_ids is None:
             return 1
         return int(np.max(self.volume_ids) + 1)
+
+    @property
+    def _unused_surface_id(self) -> int:
+        """Get unused surface ID."""
+        if self.surface_ids is None:
+            return 1
+        return int(np.max(self.surface_ids) + 1)
+
+    @property
+    def _unused_line_id(self) -> int:
+        """Get unused line ID."""
+        if self.line_ids is None:
+            return 1
+        return int(np.max(self.line_ids) + 1)
 
     @property
     def volume_names(self) -> List[str]:

--- a/src/ansys/health/heart/objects.py
+++ b/src/ansys/health/heart/objects.py
@@ -594,6 +594,28 @@ class Mesh(pv.UnstructuredGrid):
             return 1
         return int(np.max(self.surface_ids) + 1)
 
+    def get_unused_id_in_range(
+        self, id_type: Literal["volume", "surface", "line"], start: int = 1, end: int = 1000
+    ) -> int:
+        """Get an unused ID in a specified range."""
+        if id_type == "volume":
+            ids = self.volume_ids
+        elif id_type == "surface":
+            ids = self.surface_ids
+        elif id_type == "line":
+            ids = self.line_ids
+        else:
+            raise ValueError(f"Invalid id_type: {id_type}. Must be 'volume', 'surface', or 'line'.")
+
+        if ids is None:
+            return start
+
+        for ii in range(start, end + 1):
+            if ii not in ids:
+                return ii
+
+        raise ValueError(f"No unused ID found in the range {start} to {end}.")
+
     @property
     def _unused_line_id(self) -> int:
         """Get unused line ID."""


### PR DESCRIPTION
This resolves a bug where a patch and cavity can have the same ID. This removes the cap id offset before the loop and replaces it by a method to get a candidate ID within a range. We could consider using "reserved" id-ranges for particular components, but this should then also be handled for part ids, shell ids, segment ids, node set ids, etc. 