### PR TITLE
fix: purkinje on ventricle base

### DIFF
--- a/doc/source/changelog/1162.fixed.md
+++ b/doc/source/changelog/1162.fixed.md
@@ -1,0 +1,1 @@
+Purkinje on ventricle base

--- a/src/ansys/health/heart/models.py
+++ b/src/ansys/health/heart/models.py
@@ -1534,7 +1534,7 @@ class HeartModel:
             )
             eids = np.hstack((eids, eid_r))
 
-        part: anatomy.Part = self.create_part_by_ids(eids, "base")
+        part: anatomy.Part = self.create_part_by_ids(eids, "ventricular_base")
         part._part_type = anatomy._PartType.VENTRICLE
         part.fiber = False
         part.active = False

--- a/src/ansys/health/heart/writer/base_writer.py
+++ b/src/ansys/health/heart/writer/base_writer.py
@@ -589,8 +589,13 @@ class BaseDynaWriter:
     def _keep_ventricles(self) -> None:
         """Remove any non-ventricular parts."""
         LOGGER.debug("Only keeping ventricular-parts for fiber/Purkinje generation.")
+        # Note: we need to use _PartType to check part types.
+        # For example, base has _PartType as VENTRICLE,
+        # but it is not an instance from Ventricle(Part) so will be missed in writing.
         parts_to_keep = [
-            p.name for p in self.model.parts if isinstance(p, (anatomy.Ventricle, anatomy.Septum))
+            p.name
+            for p in self.model.parts
+            if p._part_type in [anatomy._PartType.VENTRICLE, anatomy._PartType.SEPTUM]
         ]
 
         self._keep_parts(parts_to_keep)


### PR DESCRIPTION
In EP-mechanical simulator, we generate Purkinje after creating ventricular base part. 
We must make sure this part is also inclued in the Purkinje generation, otherwise, it leads to PMJ nodes attached to the remaining edges of ventricle parts.

<img width="1025" height="641" alt="image" src="https://github.com/user-attachments/assets/2fef58a4-c649-44c5-a50d-0c260a092431" />


This PR fix the issue by checking the _Part_type in PurkinjeWriter