### PR TITLE
ci: Migrate to DPF 25R2

### DIFF
--- a/.github/workflows/ci_cd_main.yml
+++ b/.github/workflows/ci_cd_main.yml
@@ -10,7 +10,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ANSYS_VERSION: '241'
   ANSYS_DPF_ACCEPT_LA: 'Y'
   MAIN_PYTHON_VERSION: '3.11'
   DOCUMENTATION_CNAME: 'heart.health.docs.pyansys.com'

--- a/.github/workflows/ci_cd_main.yml
+++ b/.github/workflows/ci_cd_main.yml
@@ -52,8 +52,7 @@ jobs:
           PYANSYS_HEART_LSDYNA_PLATFORM: windows
           PYANSYS_HEART_NUM_CPU: 4
           ANSYS_DPF_ACCEPT_LA: Y
-          AWP_ROOT241: C:\\Program Files\\ANSYS Inc\\v241
-          DPF_STANDALONE_PATH: C:\\Program Files\\ANSYS Inc\\dpf-server-2024.2rc0
+          AWP_ROOT252: C:\\Program Files\\ANSYS Inc\\v252
           PYFLUENT_UI_MODE: no_gui # default hidden_gui fails on self-hosted runner
           NIGHTLY_DOC_BUILD: 0
         run: |

--- a/.github/workflows/ci_cd_night.yml
+++ b/.github/workflows/ci_cd_night.yml
@@ -116,8 +116,7 @@ jobs:
           PYANSYS_HEART_LSDYNA_PLATFORM: windows
           PYANSYS_HEART_NUM_CPU: 8
           ANSYS_DPF_ACCEPT_LA: Y
-          AWP_ROOT241: C:\\Program Files\\ANSYS Inc\\v241
-          DPF_STANDALONE_PATH: C:\\Program Files\\ANSYS Inc\\dpf-server-2024.2rc0
+          AWP_ROOT252: C:\\Program Files\\ANSYS Inc\\v252
           PYFLUENT_UI_MODE: no_gui # default hidden_gui fails on self-hosted runner
           NIGHTLY_DOC_BUILD: 1
         run: |

--- a/.github/workflows/ci_cd_night.yml
+++ b/.github/workflows/ci_cd_night.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ANSYS_VERSION: '241'
+  ANSYS_VERSION: '252'
   ANSYS_DPF_ACCEPT_LA: 'Y'
   MAIN_PYTHON_VERSION: '3.11'
   DOCUMENTATION_CNAME: 'heart.health.docs.pyansys.com'

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -128,8 +128,7 @@ jobs:
           PYANSYS_HEART_LSDYNA_PLATFORM: windows
           PYANSYS_HEART_NUM_CPU: 4
           ANSYS_DPF_ACCEPT_LA: Y
-          AWP_ROOT241: C:\\Program Files\\ANSYS Inc\\v241
-          DPF_STANDALONE_PATH: C:\\Program Files\\ANSYS Inc\\dpf-server-2024.2rc0
+          AWP_ROOT252: C:\\Program Files\\ANSYS Inc\\v252
           PYFLUENT_UI_MODE: no_gui # default hidden_gui fails on self-hosted runner
           NIGHTLY_DOC_BUILD: 0
         run: |

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ANSYS_VERSION: '241'
+  ANSYS_VERSION: '252'
   ANSYS_DPF_ACCEPT_LA: 'Y'
   MAIN_PYTHON_VERSION: '3.11'
   DOCUMENTATION_CNAME: 'heart.health.docs.pyansys.com'

--- a/.github/workflows/ci_cd_release.yml
+++ b/.github/workflows/ci_cd_release.yml
@@ -102,8 +102,7 @@ jobs:
           PYANSYS_HEART_LSDYNA_PLATFORM: windows
           PYANSYS_HEART_NUM_CPU: 4
           ANSYS_DPF_ACCEPT_LA: Y
-          AWP_ROOT241: C:\\Program Files\\ANSYS Inc\\v241
-          DPF_STANDALONE_PATH: C:\\Program Files\\ANSYS Inc\\dpf-server-2024.2rc0
+          AWP_ROOT252: C:\\Program Files\\ANSYS Inc\\v252
           PYFLUENT_UI_MODE: no_gui # default hidden_gui fails on self-hosted runner
           NIGHTLY_DOC_BUILD: 1
         run: |

--- a/.github/workflows/ci_cd_release.yml
+++ b/.github/workflows/ci_cd_release.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ANSYS_VERSION: '241'
+  ANSYS_VERSION: '252'
   ANSYS_DPF_ACCEPT_LA: 'Y'
   MAIN_PYTHON_VERSION: '3.11'
   DOCUMENTATION_CNAME: 'heart.health.docs.pyansys.com'

--- a/doc/source/changelog/1171.maintenance.md
+++ b/doc/source/changelog/1171.maintenance.md
@@ -1,0 +1,1 @@
+Use dpf 25r2 for all ci/cd workflows

--- a/src/ansys/health/heart/post/dpf_utils.py
+++ b/src/ansys/health/heart/post/dpf_utils.py
@@ -72,7 +72,7 @@ def _get_dpf_server():
         LOGGER.error(mess)
         raise SupportedDPFServerNotFoundError(mess)
 
-    return server
+    return server, version
 
 
 class D3plotReader:
@@ -90,7 +90,7 @@ class D3plotReader:
         _check_accept_dpf()
 
         # TODO: retrieve version from docker
-        self._server = _get_dpf_server()
+        self._server, self._dpf_version = _get_dpf_server()
 
         self.ds = dpf.DataSources()
         self.ds.set_result_file_path(path, "d3plot")
@@ -238,7 +238,13 @@ class D3plotReader:
 
         res = []
         for i in hv_index:
-            res.append(hist_vars[i].data)
+            if self._dpf_version.startswith("2025.2"):
+                # Skip duplicate values.
+                data = hist_vars[i].data[0::3]
+            else:
+                data = hist_vars[i].data
+
+            res.append(data)
 
         return np.array(res)
 

--- a/src/ansys/health/heart/post/dpf_utils.py
+++ b/src/ansys/health/heart/post/dpf_utils.py
@@ -35,7 +35,7 @@ from ansys.health.heart import LOG as LOGGER
 from ansys.health.heart.exceptions import SupportedDPFServerNotFoundError
 from ansys.health.heart.models import HeartModel
 
-_SUPPORTED_DPF_SERVERS = ["2025.2", "2024.1", "2024.1rc1", "2024.2rc0"]
+_SUPPORTED_DPF_SERVERS = ["2025.2", "2025.2rc0", "2024.1", "2024.1rc1", "2024.2rc0"]
 """List of supported DPF servers."""
 #! NOTE:
 #! 2024.1rc0: not supported due to missing ::tf operator

--- a/tests/heart/post/test_dpf.py
+++ b/tests/heart/post/test_dpf.py
@@ -97,7 +97,7 @@ def test_get_dpf_server(fake_servers, expected, raises):
     """Test getting the supported DPF server version."""
     with mock.patch("ansys.dpf.core.server.available_servers", return_value=fake_servers):
         if expected:
-            assert expected == _get_dpf_server()
+            assert expected == _get_dpf_server()[0]
 
         if raises:
             with pytest.raises(raises):

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,6 @@ passenv =
     PYFLUENT_*
     AWP*
     PYANSYS_HEART*
-    DPF_STANDALONE_PATH
     ANSYS*
     LSTC*
     ; Allow all environment variables to be passed to the doc build. Required by PyFluent
@@ -89,9 +88,6 @@ commands =
     # Ensure vtk compatibility
     links,html: uv pip uninstall vtk
     links,html: uv pip install --extra-index-url https://wheels.vtk.org vtk-osmesa==9.3.20240907.dev0
-
-    # Ensure DPF standalone version is installed. Managed through environment variable "DPF_STANDALONE_PATH"
-    links,html: uv pip install -e "{env:DPF_STANDALONE_PATH}"
 
     # Render documentation with desired builder
     links,html,pdf: sphinx-build -d "{toxworkdir}/doc_doctree" {env:SOURCE_DIR} "{toxinidir}/{env:BUILD_DIR}/{env:BUILDER}" {env:BUILDER_OPTS} -b {env:BUILDER}


### PR DESCRIPTION
This PR ensures compatibility with the DPF Server shipped with 25R2. 25R2 has a minor bug when reading the results, so a workaround is required for 2025.2XX versions. 

This also gets rid of the requirements for a standalone version of DPF.