### PR TITLE
feat: Support PIM for launching Fluent

### DIFF
--- a/doc/source/changelog/1188.added.md
+++ b/doc/source/changelog/1188.added.md
@@ -1,0 +1,1 @@
+Support pim fluent launch mode

--- a/src/ansys/health/heart/pre/mesher.py
+++ b/src/ansys/health/heart/pre/mesher.py
@@ -251,11 +251,13 @@ def _get_fluent_meshing_session(working_directory: str | Path) -> MeshingSession
     else:
         product_version = _fluent_version
 
+    num_cpus = int(os.getenv("PYANSYS_HEART_NUM_CPU", _num_cpus))
+
     LOGGER.info(f"Launching meshing session with {product_version}...")
 
     launch_config = {
         "precision": pyfluent.Precision.DOUBLE,
-        "processor_count": _num_cpus,
+        "processor_count": num_cpus,
         "start_transcript": False,
         "product_version": product_version,
         "ui_mode": _fluent_ui_mode,

--- a/src/ansys/health/heart/pre/mesher.py
+++ b/src/ansys/health/heart/pre/mesher.py
@@ -41,6 +41,7 @@ from ansys.health.heart.utils.vtk_utils import (
     add_solid_name_to_stl,
     cell_ids_inside_enclosed_surface,
 )
+import ansys.platform.instancemanagement as pypim
 
 _supported_fluent_versions = ["25.2", "25.1", "24.2", "24.1"]
 """List of supported Fluent versions."""
@@ -48,6 +49,8 @@ _num_cpus: bool = 2
 """Number of CPUs to use for meshing."""
 _extra_launch_kwargs = {}
 """Extra keyword arguments passed to ``pyfluent.launch_fluent()``."""
+_fluent_version = None
+"""Global variable to explicitly override the Fluent version used."""
 
 # check whether containerized version of Fluent is used
 _uses_container = bool(int(os.getenv("PYFLUENT_LAUNCH_CONTAINER", False)))
@@ -84,12 +87,6 @@ def _get_supported_fluent_version() -> str:
         f"""Did not find a supported Fluent version.
         Install one of these versions: {_supported_fluent_versions}"""
     )
-
-
-try:
-    _fluent_version = _get_supported_fluent_version()
-except Exception:
-    _fluent_version = None
 
 
 def _get_face_zones_with_filter(pyfluent_session, prefixes: list) -> list[str]:
@@ -244,6 +241,11 @@ def _get_fluent_meshing_session(working_directory: str | Path) -> MeshingSession
     # NOTE: when using containerized version - we need to copy all the files
     # to and from the mounted volume given by pyfluent.EXAMPLES_PATH (default)
 
+    # NOTE: There are three launch modes Fluent can be launched in:
+    # 1. LaunchMode.PIM: Fluent is launched using the Product Instance Management (PIM) service.
+    # 2. LaunchMode.CONTAINER: Fluent is launched in a container. (containerized mode)
+    # 3. LaunchMode.STANDALONE: Fluent is launched as a standalone application. (fallback mode)
+
     if _fluent_version is None:
         product_version = _get_supported_fluent_version()
     else:
@@ -251,36 +253,27 @@ def _get_fluent_meshing_session(working_directory: str | Path) -> MeshingSession
 
     LOGGER.info(f"Launching meshing session with {product_version}...")
 
-    if _uses_container:
-        num_cpus = 1
+    launch_config = {
+        "precision": pyfluent.Precision.DOUBLE,
+        "processor_count": _num_cpus,
+        "start_transcript": False,
+        "product_version": product_version,
+        "ui_mode": _fluent_ui_mode,
+    }
+
+    if pypim.is_configured():
+        session = pyfluent.PureMeshing.from_pim(**launch_config, **_extra_launch_kwargs)
+
+    elif _uses_container:
         custom_config = {
             "mount_source": f"{working_directory}",
             "mount_target": "/mnt/pyfluent/meshing",
         }
-
-        session = pyfluent.launch_fluent(
-            mode=pyfluent.FluentMode.MESHING,
-            precision=pyfluent.Precision.DOUBLE,
-            processor_count=num_cpus,
-            start_transcript=False,
-            product_version=product_version,
-            start_container=_uses_container,
-            container_dict=custom_config,
-            **_extra_launch_kwargs,
-        )
+        launch_config.update({"container_dict": custom_config})
+        session = pyfluent.PureMeshing.from_container(**launch_config, **_extra_launch_kwargs)
 
     else:
-        num_cpus = int(os.getenv("PYANSYS_HEART_NUM_CPU", _num_cpus))
-        session = pyfluent.launch_fluent(
-            mode=pyfluent.FluentMode.MESHING,
-            precision=pyfluent.Precision.DOUBLE,
-            processor_count=num_cpus,
-            start_transcript=False,
-            ui_mode=_fluent_ui_mode,
-            product_version=product_version,
-            start_container=_uses_container,
-            **_extra_launch_kwargs,
-        )
+        session = pyfluent.PureMeshing.from_install(**launch_config, **_extra_launch_kwargs)
 
     return session
 

--- a/src/ansys/health/heart/pre/mesher.py
+++ b/src/ansys/health/heart/pre/mesher.py
@@ -271,6 +271,7 @@ def _get_fluent_meshing_session(working_directory: str | Path) -> MeshingSession
             "mount_source": f"{working_directory}",
             "mount_target": "/mnt/pyfluent/meshing",
         }
+        launch_config["ui_mode"] = pyfluent.UIMode.NO_GUI_OR_GRAPHICS
         launch_config.update({"container_dict": custom_config})
         session = pyfluent.PureMeshing.from_container(**launch_config, **_extra_launch_kwargs)
 

--- a/src/ansys/health/heart/pre/mesher.py
+++ b/src/ansys/health/heart/pre/mesher.py
@@ -56,6 +56,7 @@ if _uses_container:
 
 _fluent_ui_mode = pyfluent.UIMode(os.getenv("PYFLUENT_UI_MODE", pyfluent.UIMode.HIDDEN_GUI))
 
+
 LOGGER.debug(f"Fluent user interface mode: {_fluent_ui_mode.value}")
 
 
@@ -258,8 +259,8 @@ def _get_fluent_meshing_session(working_directory: str | Path) -> MeshingSession
         }
 
         session = pyfluent.launch_fluent(
-            mode="meshing",
-            precision="double",
+            mode=pyfluent.FluentMode.MESHING,
+            precision=pyfluent.Precision.DOUBLE,
             processor_count=num_cpus,
             start_transcript=False,
             product_version=product_version,
@@ -271,8 +272,8 @@ def _get_fluent_meshing_session(working_directory: str | Path) -> MeshingSession
     else:
         num_cpus = int(os.getenv("PYANSYS_HEART_NUM_CPU", _num_cpus))
         session = pyfluent.launch_fluent(
-            mode="meshing",
-            precision="double",
+            mode=pyfluent.FluentMode.MESHING,
+            precision=pyfluent.Precision.DOUBLE,
             processor_count=num_cpus,
             start_transcript=False,
             ui_mode=_fluent_ui_mode,

--- a/tests/heart/pre/test_mesher.py
+++ b/tests/heart/pre/test_mesher.py
@@ -57,23 +57,27 @@ def clean_up_temp_dirs():
             pass
 
 
+@mock.patch("ansys.health.heart.pre.mesher._get_supported_fluent_version", return_value="25.2")
 def test_get_fluent_meshing_session(monkeypatch):
     """Test passing input arguments to the fluent meshing session launcher."""
 
-    expected_keys = [
-        "mode",
-        "precision",
-        "processor_count",
-        "start_transcript",
-        "ui_mode",
-        "product_version",
-        "start_container",
-    ]
+    expected_keys = set(
+        [
+            "precision",
+            "processor_count",
+            "start_transcript",
+            "ui_mode",
+            "product_version",
+        ]
+    )
 
-    with mock.patch("ansys.health.heart.pre.mesher.pyfluent.launch_fluent") as mock_launch:
+    # Test Standalone mode:
+    # with mock.patch("ansys.health.heart.pre.mesher.pyfluent.launch_fluent") as mock_launch:
+    with mock.patch("ansys.fluent.core.session_utilities.PureMeshing.from_install") as mock_launch:
         mesher._uses_container = False
         mesher._get_fluent_meshing_session(".")
-        assert list(mock_launch.call_args.kwargs.keys()) == expected_keys
+        call_args = mock_launch.call_args.kwargs.keys()
+        assert expected_keys.issubset(set(call_args))
 
         # Set additional arguments
         mock_launch.reset_mock()
@@ -81,26 +85,37 @@ def test_get_fluent_meshing_session(monkeypatch):
         mesher._get_fluent_meshing_session(".")
         assert mock_launch.call_args.kwargs["additional_arguments"] == "-ssh"
 
-        # Set number of processors
-        monkeypatch.delenv(name="PYANSYS_HEART_NUM_CPU", raising=False)
-        mock_launch.reset_mock()
-        mesher._num_cpus = 4
-        mesher._get_fluent_meshing_session(".")
-        assert mock_launch.call_args.kwargs["processor_count"] == 4
+        # Set number of through global variable.
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.delenv(name="PYANSYS_HEART_NUM_CPU", raising=False)
+            mock_launch.reset_mock()
+            mesher._num_cpus = 4
+            mesher._get_fluent_meshing_session(".")
+            assert mock_launch.call_args.kwargs["processor_count"] == 4
 
         # Set number of processors through environment variable.
-        monkeypatch.setenv(name="PYANSYS_HEART_NUM_CPU", value="100")
-        mock_launch.reset_mock()
-        mesher._get_fluent_meshing_session(".")
-        assert mock_launch.call_args.kwargs["processor_count"] == 100
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setenv(name="PYANSYS_HEART_NUM_CPU", value="100")
+            mock_launch.reset_mock()
+            mesher._get_fluent_meshing_session(".")
+            assert mock_launch.call_args.kwargs["processor_count"] == 100
 
+    # Test Container mode:
+    with mock.patch(
+        "ansys.fluent.core.session_utilities.PureMeshing.from_container"
+    ) as mock_launch:
         # Use container.
         mock_launch.reset_mock()
         mesher._uses_container = True
         mesher._get_fluent_meshing_session(".")
-        assert mock_launch.call_args.kwargs["processor_count"] == 1
-        assert mock_launch.call_args.kwargs["start_container"] is True
         assert mock_launch.call_args.kwargs["container_dict"]
+
+    # Test PIM mode:
+    with mock.patch("ansys.fluent.core.session_utilities.PureMeshing.from_pim") as mock_launch:
+        with mock.patch("ansys.platform.instancemanagement.is_configured", return_value=True):
+            mesher._get_fluent_meshing_session(".")
+            call_args = mock_launch.call_args.kwargs.keys()
+            assert expected_keys.issubset(set(call_args))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Refactoring to allow for getting a Fluent session in PIM mode. Use the static methods defined in PyFluents `SessionBase` to explicitly get the session in a certain mode.  