### PR TITLE
ci: use index-url on vtk-osmesa

### DIFF
--- a/doc/source/changelog/1255.maintenance.md
+++ b/doc/source/changelog/1255.maintenance.md
@@ -1,0 +1,1 @@
+Use index-url on vtk-osmesa

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,7 @@ commands =
 
     # Ensure vtk compatibility
     links,html: uv pip uninstall vtk
-    links,html: uv pip install --extra-index-url https://wheels.vtk.org vtk-osmesa==9.3.20240907.dev0
+    links,html: uv pip install --index-url https://wheels.vtk.org vtk-osmesa==9.3.20240907.dev0
 
     # Render documentation with desired builder
     links,html,pdf: sphinx-build -d "{toxworkdir}/doc_doctree" {env:SOURCE_DIR} "{toxinidir}/{env:BUILD_DIR}/{env:BUILDER}" {env:BUILDER_OPTS} -b {env:BUILDER}


### PR DESCRIPTION
Following internal guidelines, we will move away from ``--extra-index-url`` to ``--index-url`` when installing vtk-osmesa. Also, with the new vtk versions 9.4.X and above, vtk-osmesa is no longer required. You might be able to remove it alltogether in a follow up PR